### PR TITLE
fix(docs): resolve broken prompt link and add legacy redirects

### DIFF
--- a/catalog/Testing/Official-DotNet-Test/agents/code-testing-generator/AGENT.md
+++ b/catalog/Testing/Official-DotNet-Test/agents/code-testing-generator/AGENT.md
@@ -33,7 +33,7 @@ You coordinate test generation using the Research-Plan-Implement (RPI) pipeline.
 
 ### Step 1: Clarify the Request and Load Language Guidance
 
-Understand what the user wants: scope (project, files, classes), priority areas, framework preferences. If clear, proceed directly. If the user provides no details or a very basic prompt (e.g., "generate tests"), use [unit-test-generation.prompt.md](../skills/code-testing-agent/unit-test-generation.prompt.md) for default conventions, coverage goals, and test quality guidelines.
+Understand what the user wants: scope (project, files, classes), priority areas, framework preferences. If clear, proceed directly. If the user provides no details or a very basic prompt (e.g., "generate tests"), use [unit-test-generation.prompt.md](https://github.com/managedcode/dotnet-skills/blob/main/catalog/Testing/Official-DotNet-Test/skills/code-testing-agent/unit-test-generation.prompt.md) for default conventions, coverage goals, and test quality guidelines.
 
 Before writing code, read the language-specific base extension. Reuse it for the whole run; sub-agents must not independently reload the same reference unless they need a section that was not captured in the research document.
 

--- a/external-sources/upstreams/dotnet-skills/dotnet-test/agents/code-testing-generator.agent.md
+++ b/external-sources/upstreams/dotnet-skills/dotnet-test/agents/code-testing-generator.agent.md
@@ -33,7 +33,7 @@ You coordinate test generation using the Research-Plan-Implement (RPI) pipeline.
 
 ### Step 1: Clarify the Request and Load Language Guidance
 
-Understand what the user wants: scope (project, files, classes), priority areas, framework preferences. If clear, proceed directly. If the user provides no details or a very basic prompt (e.g., "generate tests"), use [unit-test-generation.prompt.md](../skills/code-testing-agent/unit-test-generation.prompt.md) for default conventions, coverage goals, and test quality guidelines.
+Understand what the user wants: scope (project, files, classes), priority areas, framework preferences. If clear, proceed directly. If the user provides no details or a very basic prompt (e.g., "generate tests"), use [unit-test-generation.prompt.md](https://github.com/managedcode/dotnet-skills/blob/main/catalog/Testing/Official-DotNet-Test/skills/code-testing-agent/unit-test-generation.prompt.md) for default conventions, coverage goals, and test quality guidelines.
 
 Before writing code, read the language-specific base extension. Reuse it for the whole run; sub-agents must not independently reload the same reference unless they need a section that was not captured in the research document.
 

--- a/scripts/generate_pages.py
+++ b/scripts/generate_pages.py
@@ -56,6 +56,8 @@ LEGACY_DIRECT_REDIRECTS = {
     "skills/exp-dotnet-test-frameworks/": "skills/run-tests/",
     "skills/mcp-csharp-test/": "skills/mcp/",
     "skills/libvlc/libvlc-skill.md": "skills/libvlc/",
+    "agents/skills/code-testing-agent/unit-test-generation.prompt.md": "skills/code-testing-agent/",
+    "skills/code-testing-agent/unit-test-generation.prompt.md": "skills/code-testing-agent/",
 }
 
 PLACEHOLDERS = {


### PR DESCRIPTION
## Summary of Changes (Ahrefs SEO Audit)

- **Fix Broken Prompt Links:** In `catalog/Testing/Official-DotNet-Test/agents/code-testing-generator/AGENT.md` and `external-sources/...`, replaced the relative link `../skills/...` which broke on the published website with the absolute GitHub repository URL.
- **Legacy URL Redirects:** In `scripts/generate_pages.py`, added mappings in `LEGACY_DIRECT_REDIRECTS` for `agents/skills/code-testing-agent/unit-test-generation.prompt.md` and `skills/code-testing-agent/unit-test-generation.prompt.md` pointing to `skills/code-testing-agent/` to resolve any incoming 404s.